### PR TITLE
fix unregister plugin

### DIFF
--- a/packages/djs-editor/src/EditorContainer.js
+++ b/packages/djs-editor/src/EditorContainer.js
@@ -128,7 +128,10 @@ export default class EditorContainer extends Component<Props, State> {
 
   unregisterPlugin = (key) => {
     const { plugins } = this.state
-    this.setState({plugins: plugins.delete(key)})
+
+    plugins.delete(key)
+
+    this.setState({plugins})
     this.setupEditorState()
   }
 


### PR DESCRIPTION
The delete method return true/false so when a plugin is unregistered the code breaks.